### PR TITLE
feat: panes state

### DIFF
--- a/apps/site/src/components/chat/Chat.tsx
+++ b/apps/site/src/components/chat/Chat.tsx
@@ -1,9 +1,7 @@
 import type { FC } from 'react';
-import { useEffect } from 'react';
 import { Suspense } from 'react';
 import { Loading } from 'ui';
 import { useSpace } from '../../hooks/useSpace';
-import { useChatDispatch } from '../../state/atoms/chat';
 import { PaneProvider, usePanes } from '../../state/panes';
 import { ChatView } from './ChatView';
 
@@ -14,8 +12,6 @@ interface Props {
 const Chat: FC<Props> = ({ spaceId }) => {
   const space = useSpace(spaceId);
   const { panes, dispatch, focused } = usePanes(spaceId);
-  const chatDispatch = useChatDispatch();
-  useEffect(() => chatDispatch('enterSpace', { spaceId }), [chatDispatch, spaceId]);
 
   return (
     <Suspense

--- a/apps/site/src/components/chat/PaneCreateChannel.tsx
+++ b/apps/site/src/components/chat/PaneCreateChannel.tsx
@@ -3,10 +3,9 @@ import { FormProvider, useController, useForm, useFormContext } from 'react-hook
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useSWRConfig } from 'swr';
 import { Button, TextInput } from 'ui';
-import { makeId } from 'utils';
 import { post } from '../../api/browser';
 import { useChatPaneDispatch, useClosePane } from '../../state/panes';
-import type { ChannelPane } from '../../types/chat-pane';
+import { makePane } from '../../types/chat-pane';
 import { DiceSelect } from '../DiceSelect';
 import { ClosePaneButton } from './ClosePaneButton';
 import { PaneBodyBox } from './PaneBodyBox';
@@ -110,7 +109,7 @@ export const PaneCreateChannel: FC<Props> = ({ spaceId }) => {
     }
     const { channel } = result.unwrap();
     await mutate(['/channels/by_space', spaceId]);
-    const newChannelPane: ChannelPane = { type: 'CHANNEL', channelId: channel.id, id: makeId() };
+    const newChannelPane = makePane({ type: 'CHANNEL', channelId: channel.id });
     dispatch({ type: 'REPLACE_PANE', item: newChannelPane });
   };
   return (

--- a/apps/site/src/components/chat/sidebar/ChatSidebarFooter.tsx
+++ b/apps/site/src/components/chat/sidebar/ChatSidebarFooter.tsx
@@ -2,9 +2,8 @@ import { HelpCircle, Settings } from 'icons';
 import type { FC } from 'react';
 import { useIntl } from 'react-intl';
 import { Button } from 'ui/Button';
-import { Indicator } from 'ui/Indicator';
 import { useChatPaneDispatch } from '../../../state/panes';
-import type { HelpPane, SettingsPane } from '../../../types/chat-pane';
+import { makePane, Pane } from '../../../types/chat-pane';
 
 interface Props {
   className?: string;
@@ -20,7 +19,7 @@ const SettingToggleButton: FC<{ on: boolean; isExpand: boolean }> = ({ on, isExp
   const label = on
     ? intl.formatMessage({ defaultMessage: 'Open {paneName}' }, { paneName })
     : intl.formatMessage({ defaultMessage: 'Close {paneName}' }, { paneName });
-  const pane: SettingsPane = { type: 'SETTINGS', id: 'settings' };
+  const pane: Pane = makePane({ type: 'SETTINGS' });
   return (
     <Button
       onClick={() => dispatch({ type: 'TOGGLE', pane })}
@@ -43,7 +42,7 @@ const HelpToggleButton: FC<{ on: boolean; isExpand: boolean }> = ({ on, isExpand
   const label = on
     ? intl.formatMessage({ defaultMessage: 'Open {paneName}' }, { paneName })
     : intl.formatMessage({ defaultMessage: 'Close {paneName}' }, { paneName });
-  const pane: HelpPane = { type: 'HELP', id: 'help' };
+  const pane: Pane = makePane({ type: 'HELP' });
   return (
     <Button
       onClick={() => dispatch({ type: 'TOGGLE', pane })}

--- a/apps/site/src/components/chat/sidebar/SidebarChannelList.tsx
+++ b/apps/site/src/components/chat/sidebar/SidebarChannelList.tsx
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl';
 import { Button } from 'ui';
 import { useChannelList } from '../../../hooks/useChannelList';
 import { useChatPaneDispatch } from '../../../state/panes';
-import type { Pane } from '../../../types/chat-pane';
+import { makePane, Pane } from '../../../types/chat-pane';
 import { SidebarChannelItem } from './SidebarChannelItem';
 
 interface Props {
@@ -20,7 +20,7 @@ export const SidebarChannelList: FC<Props> = ({ spaceId, panes }) => {
   );
   const dispatch = useChatPaneDispatch();
   const handleOpenCreateChannelPane = () => {
-    dispatch({ type: 'TOGGLE', pane: { type: 'CREATE_CHANNEL', id: 'create_channel', spaceId } });
+    dispatch({ type: 'TOGGLE', pane: makePane({ type: 'CREATE_CHANNEL', spaceId }) });
   };
   const isCreateChannelPaneOpened = useMemo(() => panes.find(pane => pane.type === 'CREATE_CHANNEL') !== undefined, [
     panes,

--- a/apps/site/src/components/chat/sidebar/SpaceOptions.tsx
+++ b/apps/site/src/components/chat/sidebar/SpaceOptions.tsx
@@ -6,7 +6,7 @@ import { useState } from 'react';
 import { useMemo } from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useChatPaneDispatch } from '../../../state/panes';
-import type { Pane, SpaceSettingsPane } from '../../../types/chat-pane';
+import { makePane, Pane, SpaceSettingsPane } from '../../../types/chat-pane';
 import { SidebarItem } from './SidebarItem';
 
 interface Props {
@@ -17,7 +17,7 @@ interface Props {
 export const SpaceOptions: FC<Props> = ({ space, panes }) => {
   const dispatch = useChatPaneDispatch();
   const [folded, setFold] = useState(true);
-  const spaceSettingsPane: SpaceSettingsPane = { type: 'SPACE_SETTINGS', id: space.id, spaceId: space.id };
+  const spaceSettingsPane: SpaceSettingsPane = { type: 'SPACE_SETTINGS', spaceId: space.id };
   const spaceSettingsActive = useMemo(() => panes.findIndex(pane => pane.type === 'SPACE_SETTINGS') !== -1, [panes]);
   return (
     <div className={folded ? '' : 'border-b'}>
@@ -40,7 +40,7 @@ export const SpaceOptions: FC<Props> = ({ space, panes }) => {
           <SidebarItem
             icon={<Settings />}
             active={spaceSettingsActive}
-            onClick={() => dispatch({ type: 'TOGGLE', pane: spaceSettingsPane })}
+            onClick={() => dispatch({ type: 'TOGGLE', pane: makePane(spaceSettingsPane) })}
             toggle
           >
             <FormattedMessage defaultMessage="Space Settings" />

--- a/apps/site/src/state/actions/chat.tsx
+++ b/apps/site/src/state/actions/chat.tsx
@@ -6,6 +6,7 @@ export type ChatActionMap = {
   receiveMessage: { channelId: string; message: Message };
   initialized: Empty;
   enterSpace: { spaceId: string };
+  panesChange: { channelIdSet: Set<string> };
   spaceUpdated: SpaceWithRelated;
   messagesLoaded: { messages: Message[]; before: number | null; channelId: string; fullLoaded: boolean };
   messageEdited: { message: Message; channelId: string };

--- a/apps/site/src/state/channel.ts
+++ b/apps/site/src/state/channel.ts
@@ -7,10 +7,11 @@ export interface ChannelState {
   fullLoaded: boolean;
   messages: MessageItem[];
   previewMap: Record<string, PreviewItem>; // Key: User ID
+  opened: boolean;
 }
 
 export const makeInitialChannelState = (id: string): ChannelState => {
-  return { id, messages: [], fullLoaded: false, previewMap: {} };
+  return { id, messages: [], fullLoaded: false, previewMap: {}, opened: false };
 };
 
 const handleNewMessage = (state: ChannelState, { payload }: ChatAction<'receiveMessage'>): ChannelState => {

--- a/apps/site/src/types/chat-pane.ts
+++ b/apps/site/src/types/chat-pane.ts
@@ -1,34 +1,76 @@
+import { makeId } from 'utils';
+
 export interface ChannelPane {
   type: 'CHANNEL';
-  id: string;
   channelId: string;
 }
 
 export interface SettingsPane {
   type: 'SETTINGS';
-  id: 'settings';
 }
 
 export interface HelpPane {
   type: 'HELP';
-  id: 'help';
 }
 
 export interface SpaceSettingsPane {
   type: 'SPACE_SETTINGS';
-  id: string;
   spaceId: string;
 }
 
 export interface CreateChannelPane {
   type: 'CREATE_CHANNEL';
-  id: 'create_channel';
   spaceId: string;
 }
 
 export interface EmptyPane {
   type: 'EMPTY';
-  id: string;
 }
 
-export type Pane = ChannelPane | EmptyPane | SettingsPane | HelpPane | SpaceSettingsPane | CreateChannelPane;
+export type PaneData = ChannelPane | EmptyPane | SettingsPane | HelpPane | SpaceSettingsPane | CreateChannelPane;
+
+export type Pane = PaneData & {
+  id: string;
+};
+
+export function isPaneData(pane: unknown): pane is PaneData {
+  if (typeof pane !== 'object' || pane === null) {
+    return false;
+  }
+  if (!('type' in pane) || typeof pane.type !== 'string') {
+    return false;
+  }
+  return true;
+}
+
+export const isSamePaneData = (paneData: PaneData, pane: Pane): boolean => {
+  if (paneData.type !== pane.type) {
+    return false;
+  }
+  switch (paneData.type) {
+    case 'CHANNEL':
+      return paneData.channelId === (pane as ChannelPane).channelId;
+    case 'SPACE_SETTINGS':
+      return paneData.spaceId === (pane as SpaceSettingsPane).spaceId;
+    case 'CREATE_CHANNEL':
+      return paneData.spaceId === (pane as CreateChannelPane).spaceId;
+    default:
+      return true;
+  }
+};
+
+export const makePane = (paneData: PaneData): Pane => {
+  const { type } = paneData;
+  switch (paneData.type) {
+    case 'HELP':
+      return { ...paneData, id: type };
+    case 'SETTINGS':
+      return { ...paneData, id: type };
+    case 'CREATE_CHANNEL':
+      return { ...paneData, id: type };
+    case 'SPACE_SETTINGS':
+      return { ...paneData, id: type };
+    default:
+      return { ...paneData, id: makeId() };
+  }
+};


### PR DESCRIPTION
- Serialize pane state (`PaneData[]`) in the hash part of URL
- Added an `opened` field to the `ChannelState` to reflect whether the channel's pane is open or not
- Clean up unopened channels for `chatListAtomFamily`