### PR TITLE
chore(devcontainers): do not build arm64 image for now

### DIFF
--- a/.github/workflows/dev-image.yaml
+++ b/.github/workflows/dev-image.yaml
@@ -27,7 +27,7 @@ jobs:
         with:
           push: true
           file: .devcontainer/Dockerfile.prebuild
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
           provenance: true


### PR DESCRIPTION
Because strange failure:

```
curl -L https://nixos.org/nix/install | sh -s -- --no-daemon;
curl: (55) Send failure: Broken pipe
```