### PR TITLE
spa, ui: move preview drag transform conversion out of shared UI

### DIFF
--- a/apps/spa/components/pane-channel/SelfPreview.tsx
+++ b/apps/spa/components/pane-channel/SelfPreview.tsx
@@ -20,6 +20,7 @@ import { useSelfPreviewAutoHide } from '../../hooks/useSelfPreviewAutoHide';
 import { useReadObserve } from '../../hooks/useReadObserve';
 import { useIsInGameChannel } from '../../hooks/useIsInGameChannel';
 import { useSortable } from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
 import { useScrollerRef } from '../../hooks/useScrollerRef';
 import { useVirtuosoRef } from '../../hooks/useVirtuosoRef';
 import { useMember } from '../../hooks/useMember';
@@ -257,7 +258,7 @@ export const SelfPreview: FC<Props> = ({ preview, isLast, displayIndex }) => {
         onDrop={onDrop}
         pos={preview.pos}
         isInGameChannel={isInGameChannel}
-        transform={transform}
+        transform={CSS.Transform.toString(transform)}
         transition={transition}
         onMouseEnter={() => setSelfPreviewHover(true)}
         onMouseLeave={() => setSelfPreviewHover(false)}

--- a/package-lock.json
+++ b/package-lock.json
@@ -21392,7 +21392,6 @@
         "@boluo/icons": "0.0.0",
         "@boluo/types": "0.0.0",
         "@boluo/utils": "0.0.0",
-        "@dnd-kit/utilities": "^3.2.2",
         "@floating-ui/react": "^0.27.19",
         "clsx": "^2.1.1",
         "react-intl": "^10.1.14",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,7 +7,6 @@
     "@boluo/icons": "0.0.0",
     "@boluo/types": "0.0.0",
     "@boluo/utils": "0.0.0",
-    "@dnd-kit/utilities": "^3.2.2",
     "@floating-ui/react": "^0.27.19",
     "clsx": "^2.1.1",
     "react-intl": "^10.1.14",

--- a/packages/ui/src/chat/PreviewBox.tsx
+++ b/packages/ui/src/chat/PreviewBox.tsx
@@ -1,5 +1,4 @@
 import clsx from 'clsx';
-import { CSS, type Transform } from '@dnd-kit/utilities';
 import { type CSSProperties, type DragEventHandler, type FC } from 'react';
 import { PreviewHandlePlaceHolder } from '../PreviewHandlePlaceHolder';
 
@@ -14,8 +13,8 @@ interface Props {
   children: React.ReactNode;
   onDrop?: DragEventHandler;
   inEditMode?: boolean;
-  transform?: Transform | null;
-  transition?: string | undefined;
+  transform?: CSSProperties['transform'];
+  transition?: CSSProperties['transition'];
   isSelf?: boolean;
   onMouseEnter?: React.MouseEventHandler<HTMLDivElement>;
   onMouseLeave?: React.MouseEventHandler<HTMLDivElement>;
@@ -36,7 +35,7 @@ export const PreviewBox: FC<Props> = ({
   children,
   inEditMode = false,
   onDrop,
-  transform = null,
+  transform,
   transition,
   isSelf = false,
   onMouseEnter,
@@ -45,7 +44,7 @@ export const PreviewBox: FC<Props> = ({
   handle,
 }) => {
   const style: CSSProperties & { '--bg-angle': string } = {
-    transform: CSS.Transform.toString(transform),
+    transform,
     transition,
     '--bg-angle': isSelf ? '135deg' : '225deg',
     ...(disablePreviewStyle


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved drag-and-drop preview positioning by ensuring transforms are applied correctly.
  - Updated preview styling to handle transform and transition values more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->