### PR TITLE
spa: pass channel default mode explicitly to compose counters

### DIFF
--- a/apps/spa/counters/useComposeCountersAtom.ts
+++ b/apps/spa/counters/useComposeCountersAtom.ts
@@ -5,7 +5,6 @@ import { parseModifiers, needsVariableEnvironment } from '@boluo/interpreter';
 import { useQueryEntries } from '@boluo/hooks/useQueryEntries';
 import { useQueryEntriesByComponent } from '@boluo/hooks/useQueryEntriesByComponent';
 import { useMember } from '../hooks/useMember';
-import { useDefaultInGame } from '../hooks/useDefaultInGame';
 import { resolveSpeakerMode, type SpeakerAttribution } from '../characters/resolveSpeaker';
 import { usePortrayableCharacters } from '../hooks/usePortrayableCharacters';
 import type { ComposeState } from '../state/compose.reducer';
@@ -58,9 +57,9 @@ export const resolveCounterTarget = ({
 
 export const useComposeCountersAtom = (
   composeAtom: Atom<ComposeState>,
+  defaultInGame: boolean,
 ): Atom<ComposeCountersState> => {
   const member = useMember();
-  const defaultInGame = useDefaultInGame();
   const { characters, error: characterError } = usePortrayableCharacters(member?.space.spaceId);
   const source = useAtomValue(
     useMemo(() => selectAtom(composeAtom, (state) => state.source), [composeAtom]),

--- a/apps/spa/hooks/useChannelAtoms.tsx
+++ b/apps/spa/hooks/useChannelAtoms.tsx
@@ -91,7 +91,7 @@ export const useMakeChannelAtoms = (
     defaultDiceFaceRef.current = defaultDiceFace;
   }, [defaultDiceFace]);
   const composeAtom = composeAtomFamily({ channelId, paneKey });
-  const countersStateAtom = useComposeCountersAtom(composeAtom);
+  const countersStateAtom = useComposeCountersAtom(composeAtom, defaultInGame);
   const checkComposeAtom: Atom<ComposeError | null> = useMemo(
     () => selectAtom(composeAtom, checkCompose(characterName, defaultInGame)),
     [characterName, composeAtom, defaultInGame],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Counter state now initializes using the channel’s configured in-game mode, improving consistency when composing messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->