### PR TITLE
legacy, spa: ignore stale message versions in position collision checks

### DIFF
--- a/apps/legacy/src/reducers/chatState.ts
+++ b/apps/legacy/src/reducers/chatState.ts
@@ -650,9 +650,21 @@ const handleChannelEvent = (chat: ChatState, event: Events, myId: Id | undefined
   }
   if (body.type === 'NEW_MESSAGE' || body.type === 'MESSAGE_EDITED') {
     const incomingMessage = body.message;
+    const currentItem = itemSet.messages.find(
+      (item) => item.type === 'MESSAGE' && item.id === incomingMessage.id,
+    );
+    const currentMessage = currentItem?.type === 'MESSAGE' ? currentItem.message : null;
+    const versionComparison = currentMessage
+      ? compareMessageVersion(currentMessage, incomingMessage)
+      : null;
+    // Old message versions should not trigger collision warnings.
+    const ignoredByVersion =
+      versionComparison !== null &&
+      (body.type === 'NEW_MESSAGE' ? versionComparison >= 0 : versionComparison > 0);
     const itemIndexByPos = binarySearchPos(itemSet.messages, incomingMessage.pos);
     const itemByPos = itemSet.messages.get(itemIndexByPos);
     if (
+      !ignoredByVersion &&
       itemByPos?.type === 'MESSAGE' &&
       itemByPos.pos === incomingMessage.pos &&
       itemByPos.id !== incomingMessage.id
@@ -665,6 +677,10 @@ const handleChannelEvent = (chat: ChatState, event: Events, myId: Id | undefined
         details: {
           conflictingMessage: messageDiagnostic(itemByPos.message),
           incomingMessage: messageDiagnostic(incomingMessage),
+          currentMessage: currentMessage ? messageDiagnostic(currentMessage) : null,
+          oldPos: body.type === 'MESSAGE_EDITED' ? body.oldPos : null,
+          updateLive: event.live ?? null,
+          initialized: chat.initialized,
         },
       });
     }

--- a/apps/spa/state/channel.reducer.ts
+++ b/apps/spa/state/channel.reducer.ts
@@ -355,6 +355,10 @@ const handleNewMessage = (
   }
   const [insertIndex, itemByPos] = binarySearchPosList(messages, message.pos);
   if (itemByPos) {
+    // Replayed creation events may predate the version already loaded from history.
+    if (itemByPos.id === message.id && compareMessageVersion(itemByPos, message) >= 0) {
+      return { ...state, previewMap, optimisticMessageMap };
+    }
     if (itemByPos.id !== message.id || itemByPos.modified !== message.modified) {
       const logContext = channelLogContext(state, action);
       recordWarn(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Reduced duplicate or outdated message warnings when older message events are replayed.
  - Prevented unnecessary chat history refreshes for repeated message creation events.
  - Improved diagnostic details when message position conflicts occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->